### PR TITLE
refactored. Logic once again condensed into order_jobs class.

### DIFF
--- a/spec/job_processor_spec.rb
+++ b/spec/job_processor_spec.rb
@@ -2,92 +2,116 @@ require 'job_processor'
 
 describe JobProcessor do
 
-  describe 'return_ordered_jobs(jobs)' do
+  describe 'ordered_jobs' do
 
     it 'returns an empty string when passed an empty string (no jobs)' do
       job_processor = JobProcessor.new("")
-      expect(job_processor.return_ordered_jobs).to eq ""
+      expect(job_processor.ordered_jobs).to eq ""
     end
 
     it 'returns a single job when passed a single job (a)' do
       job_processor = JobProcessor.new("a => ")
-      expect(job_processor.return_ordered_jobs).to eq "a"
+      expect(job_processor.ordered_jobs).to eq "a"
     end
 
     it 'returns all jobs in any order when given multiple jobs without dependencies (abc)' do
       job_processor = JobProcessor.new("a => , b => , c => ")
-      expect(job_processor.return_ordered_jobs).to eq "abc"
+      expect(job_processor.ordered_jobs).to eq "abc"
     end
 
     it 'returns a single job with a dependency in order' do
       job_processor = JobProcessor.new("a => , b => c, c => ")
-      expect(job_processor.return_ordered_jobs).to eq "acb"
+      expect(job_processor.ordered_jobs).to eq "acb"
     end
 
     it 'returns a single job with a dependency in order - 2' do
       job_processor = JobProcessor.new("a => b, b => , c => ")
-      expect(job_processor.return_ordered_jobs).to eq "bca"
+      expect(job_processor.ordered_jobs).to eq "bac"
     end
 
     it 'returns a single job with a dependency in order - 3' do
       job_processor = JobProcessor.new("a => , b => , c => a")
-      expect(job_processor.return_ordered_jobs).to eq "abc"
+      expect(job_processor.ordered_jobs).to eq "abc"
     end
 
     it 'returns a list of jobs with multiple dependencies in order' do
       job_processor = JobProcessor.new("a => , b => c, c => f, d => a, e => b, f => ")
-      expect(job_processor.return_ordered_jobs).to eq "afcdbe"
+      expect(job_processor.ordered_jobs).to eq "afcbde"
     end
 
     it 'returns a list of jobs with multiple dependencies in order (testing different combinations: 2)' do
       job_processor = JobProcessor.new("a => b, b => c, c => f, d => a, e => , f => ")
-      expect(job_processor.return_ordered_jobs).to eq "efcbad"
+      expect(job_processor.ordered_jobs).to eq "fcbade"
     end
 
     it 'returns a list of jobs with multiple dependencies in order (testing different combinations: 3)' do
       job_processor = JobProcessor.new("a => f, b => e, c => a, d => , e => d, f => ")
-      expect(job_processor.return_ordered_jobs).to eq "dfaceb"
+      expect(job_processor.ordered_jobs).to eq "fadebc"
     end
 
     it 'returns a list of jobs with multiple dependencies in order (testing different combinations: 4)' do
       job_processor = JobProcessor.new("a => , b => , c => a, d => f, e => b, f => e")
-      expect(job_processor.return_ordered_jobs).to eq "abcefd"
-
+      expect(job_processor.ordered_jobs).to eq "abcefd"
     end
 
     it 'returns a list of jobs with multiple dependencies in order (testing different combinations: 5)' do
       job_processor = JobProcessor.new("a => d, b => , c => f, d => , e => , f => e")
-      expect(job_processor.return_ordered_jobs).to eq "bdeafc"
+      expect(job_processor.ordered_jobs).to eq "dabefc"
     end
 
     it 'returns a list of jobs with multiple dependencies in order (testing different combinations: 6)' do
       job_processor = JobProcessor.new("a => , b => , c => a, d => c, e => , f => ")
-      expect(job_processor.return_ordered_jobs).to eq "abefcd"
+      expect(job_processor.ordered_jobs).to eq "abcdef"
+    end
+
+    it 'returns a list of jobs with 5 dependencies in order' do
+      job_processor = JobProcessor.new("a => b, b => c, c => d, d => e, e => f, f => ")
+      expect(job_processor.ordered_jobs).to eq "fedcba"
+    end
+
+    it 'returns a list of jobs with 5 dependencies in order (different combination: 2)' do
+      job_processor = JobProcessor.new("a => , b => a, c => d, d => b, e => c, f => e")
+      expect(job_processor.ordered_jobs).to eq "abdcef"
+    end
+
+    it 'returns a list of jobs with 5 dependencies in order (different combination: 3)' do
+      job_processor = JobProcessor.new("a => d, b => a, c => , d => e, e => c, f => e")
+      expect(job_processor.ordered_jobs).to eq "cedabf"
+    end
+
+    it 'works when passed a list of jobs that has 5 dependencies' do
+      job_processor = JobProcessor.new("a => b, b => c, c => d, d => e, e => f, f => ")
+      expect(job_processor.ordered_jobs).to eq "fedcba"
     end
 
     it 'returns an error when passed a job that depends on itself e.g. (c => c)' do
       job_processor = JobProcessor.new("a => , b => , c => c")
-      expect { job_processor.return_ordered_jobs }.to raise_error "A job can't depend on itself."
+      expect { job_processor.ordered_jobs }.to raise_error "A job can't depend on itself."
     end
 
-    it 'returns an error when passed a job that depends on itself (testing different combinations: 2))' do
+    it 'returns an error when passed a job that depends on itself (different combination: 2))' do
       job_processor = JobProcessor.new("a => , b => a, c => , d => e, e => , f => f")
-      expect { job_processor.return_ordered_jobs }.to raise_error "A job can't depend on itself."
+      expect { job_processor.ordered_jobs }.to raise_error "A job can't depend on itself."
     end
 
     it 'returns an error when passed a job that has circular dependencies' do
       job_processor = JobProcessor.new("a => , b => c, c => f, d => a, e => , f => b")
-      expect { job_processor.return_ordered_jobs }.to raise_error "Jobs can't have circular dependencies."
+      expect { job_processor.ordered_jobs }.to raise_error "Jobs can't have circular dependencies."
     end
 
     it 'returns an error when passed a job that has circular dependencies (different combination: 2)' do
       job_processor = JobProcessor.new("a => b, b => a")
-      expect { job_processor.return_ordered_jobs }.to raise_error "Jobs can't have circular dependencies."
+      expect { job_processor.ordered_jobs }.to raise_error "Jobs can't have circular dependencies."
     end
 
     it 'returns an error when passed a job that has circular dependencies (different combination: 3)' do
       job_processor = JobProcessor.new("a => b, b => c, c => a")
-      expect { job_processor.return_ordered_jobs }.to raise_error "Jobs can't have circular dependencies."
+      expect { job_processor.ordered_jobs }.to raise_error "Jobs can't have circular dependencies."
+    end
+
+    it 'returns an error when passed a job that has circular dependencies (different combination: 4)' do
+      job_processor = JobProcessor.new("a => b, b => d, c => a, d => a, e => f, f=> ")
+      expect { job_processor.ordered_jobs }.to raise_error "Jobs can't have circular dependencies."
     end
   end
 end


### PR DESCRIPTION
All tests passing.
I previously extracted some of the order_jobs logic out into separate methods; however, this felt a tad pointless. It also felt like it was violating the DRY principle.
Some methods have been renamed to better reflect what they do and I have removed an unnecessary instance variable.
Lastly, I have added a couple of tests for an edge case I previously overlooked. My previous code didn't work as intended when passed sequential dependencies, e.g. ("a => b, b => c, c => d, d => e, e => f, f => ") - this has now been addressed.